### PR TITLE
From 3s to 3000 in timer component period option, related to CAMEL-14575

### DIFF
--- a/Routing.java
+++ b/Routing.java
@@ -15,7 +15,7 @@ public class Routing extends RouteBuilder {
   @Override
   public void configure() throws Exception {
 
-      from("timer:java?period=3s")
+      from("timer:java?period=3000")
         .id("generator")
         .bean(this, "generateRandomItem({{items}})")
         .choice()


### PR DESCRIPTION
From 3.2.0 this will only work with 3000, because in CAMEL-14575 we drop time pattern.